### PR TITLE
Proプラン解約に伴うレイアウト調整

### DIFF
--- a/assets/css/hatena-config/design.scss
+++ b/assets/css/hatena-config/design.scss
@@ -544,7 +544,7 @@ ul.table-of-contents {
 
 .gnav  {
   position: absolute; //ロゴの横に移動
-  top: .8rem;
+  top: 3.2rem;
   left: 5.4rem;
   width: calc(100% - 5.8rem);
 }

--- a/assets/css/hatena-config/freeplan.scss
+++ b/assets/css/hatena-config/freeplan.scss
@@ -8,3 +8,8 @@
 }
 
 // globalfooter
+
+#footer #footer-inner {
+  padding: 2rem;
+  background-color: $color_dark-bg-key1;
+}

--- a/assets/css/hatena-config/freeplan.scss
+++ b/assets/css/hatena-config/freeplan.scss
@@ -1,0 +1,10 @@
+// globalheader
+
+#globalheader {
+  display: block;
+  width: 100%;
+  height: 37px;
+  background-color: #000;
+}
+
+// globalfooter

--- a/assets/css/hatena-config/responsive.scss
+++ b/assets/css/hatena-config/responsive.scss
@@ -73,7 +73,7 @@
   }
   .search-form {
     position: absolute;
-    top: 16rem;
+    top: 18rem;
     left: .5rem;
     width: 11.5rem;
     z-index: 20;

--- a/assets/css/hatena-config/responsive.scss
+++ b/assets/css/hatena-config/responsive.scss
@@ -40,7 +40,7 @@
   #content {
     overflow-y: scroll;
     -ms-overflow-style: none;
-    height: calc(100vh - 2rem);
+    height: calc(100vh - 2rem - 37px);
   }
   // パンくずがないページの調整
   .page-index #container-inner,
@@ -52,7 +52,7 @@
   }
   .page-index #content,
   .page-about #content {
-    height: 100vh;
+    height: calc(100vh - 37px);
   }
 
   // ヘッダー画像のサイズ調整

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -15,6 +15,8 @@
 @import "hatena-config/responsive";
 @import "hatena-config/darkmode";
 
+@import "hatena-config/freeplan";
+
 /*!
 
 ↑末尾のコメントアウトを外して管理画面に貼り付け

--- a/components/layouts/globalfooter.vue
+++ b/components/layouts/globalfooter.vue
@@ -1,0 +1,16 @@
+<template lang="pug">
+  footer#footer
+    #footer-inner
+      .guest-footer.js-guide-register.test-blogs-register-guide
+        .guest-footer-content
+          h3 はてなブログをはじめよう！
+          p rokuzeudonさんは、はてなブログを使っています。あなたもはてなブログをはじめてみませんか？
+          .guest-footer-btn-container
+            .guest-footer-btn
+              a.btn.btn-register.js-inherit-ga はてなブログをはじめる（無料）
+            .guest-footer-btn
+              a はてなブログとは
+      address.footer-address
+        a: span.footer-address-name LOGzeudon with はてなブログ
+      p.services Powered by Hatena Blog | ブログを報告する
+</template>

--- a/components/layouts/globalheader.vue
+++ b/components/layouts/globalheader.vue
@@ -1,0 +1,4 @@
+<template lang="pug">
+  #globalheader-container
+    #globalheader
+</template>

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,6 @@
 <template lang="pug">
   .page-index.header-image-only.page-archive.globalheader-off
+    c_GlobalHeader
     #container
       #container-inner
         //- header
@@ -23,4 +24,5 @@
                       a(href="#" rel="next") 次のページ
             c_Box2
         c_BottomEditarea
+    c_GlobalFooter
 </template>

--- a/pages/page-entry/index.vue
+++ b/pages/page-entry/index.vue
@@ -1,5 +1,6 @@
 <template lang="pug">
   .page-entry.header-image-only.globalheader-off
+    c_GlobalHeader
     #container
       #container-inner
         //- header
@@ -51,7 +52,7 @@
                           img.mv(title="" src="//data.rokuzeudon.com/blog/img/bootstrap-xd.svg" alt="AdobeXDで使えるBootstrap4のテンプレートデータをつくってみた（Mac向け）")
                         p テキストが入ります
                         ul.table-of-contents
-                          li 
+                          li
                             a(href="#heading1") 大見出し
                             ul
                               li
@@ -219,4 +220,5 @@
                 #box1-inner
             c_Box2
         c_BottomEditarea
+    c_GlobalFooter
 </template>

--- a/plugins/load-components.js
+++ b/plugins/load-components.js
@@ -3,6 +3,8 @@ import Vue from 'vue'
 import c_ArchiveEntry from '~/components/layouts/archive-entry'
 import c_Header from '~/components/layouts/header'
 import c_Box2 from '~/components/layouts/box2'
+import c_GlobalHeader from '~/components/layouts/globalheader'
+import c_GlobalFooter from '~/components/layouts/globalfooter'
 import c_TopEditarea from '~/components/edit/top-editarea'
 import c_BottomEditarea from '~/components/edit/bottom-editarea'
 import c_EntryHeaderHtml from '~/components/edit/entry-header-html'
@@ -13,6 +15,8 @@ Vue.mixin({
     c_ArchiveEntry,
     c_Header,
     c_Box2,
+    c_GlobalHeader,
+    c_GlobalFooter,
     c_TopEditarea,
     c_BottomEditarea,
     c_EntryHeaderHtml,


### PR DESCRIPTION
* globalheader(はてなブログヘッダー)が表示されるようになり、固定配置していた要素が下にずれたり、100vhのコンテンツ部分が画面をはみ出たりしていたので修正した
* footer#footer(はてなブログフッター)が表示されるようになり、スタイルが当たっていなかったので当てた

修正後

![image](https://user-images.githubusercontent.com/14285777/103180423-04c42a80-48d9-11eb-9c72-89a8ed10ad27.png)
![image](https://user-images.githubusercontent.com/14285777/103180425-0988de80-48d9-11eb-98ee-e1b3732b50dd.png)
![image](https://user-images.githubusercontent.com/14285777/103180428-11e11980-48d9-11eb-8288-83699816be19.png)
